### PR TITLE
Adds an option to not recoursivly resolve DNS names that are not defi…

### DIFF
--- a/testhandler.py
+++ b/testhandler.py
@@ -1,0 +1,21 @@
+def init():
+   """Optional function to initialize plugin.
+   """
+   print "TestHandler initialized."
+
+def handle(request,response):
+   """Optional function called with the request and response that will be sent in 
+      in response to the query. This is called within the DNSChef thread, so any 
+      long precessing should be spawned into another thread.
+      :param request: dnslib.DNSRecord for the request
+      :param response: dnslib.DNSRecord for the response
+      
+      The return value from this function will be sent in response to the query.
+
+   """
+   print "in handle."
+   print "---------------------------   request ----------------------------"
+   print repr(request)
+   print "---------------------------   response ----------------------------"
+   print repr(response)
+   return response


### PR DESCRIPTION
Adds an option to not recursively resolve DNS names that are not defined as part of those that are being cooked.

Adds an option to specify a python module that can implement an init and handle function that  will be called at start up and when handling requests respectively. The result of the handle method is what is sent as the response to the query allowing for programmatic modification of the response.