### PR TITLE
FIX: [Errno -2] Name or service not known

### DIFF
--- a/dnschef.py
+++ b/dnschef.py
@@ -51,6 +51,7 @@ import os
 import binascii
 import string
 import base64
+import re
 
 
 class DNSChefFormatter(logging.Formatter):
@@ -266,7 +267,7 @@ class DNSHandler():
                 else:
                     log.info(f"{self.client_address[0]}: proxying the response of type '{qtype}' for {qname}")
 
-                    nameserver_tuple = random.choice(self.server.nameservers).split('#')
+                    nameserver_tuple = re.split('[#:]',random.choice(self.server.nameservers))
                     response = self.proxyrequest(data, *nameserver_tuple)
 
         return response


### PR DESCRIPTION
I am using dnsmasq and dnscrypt-proxy as local dns server.  When i try to resolve a domain using dnschef -> dnsmasq -> dnscrypt-proxy i am getting error:

`[!] [!] Could not proxy request: [Errno -2] Name or service not known`

This PR fixes the issue by using regex split for `#` and `:` characters. On my server `self.server.nameservers` returns x.x.x.x:port instead of x.x.x.x#port