### PR TITLE
Update dnschef.py

### DIFF
--- a/dnschef.py
+++ b/dnschef.py
@@ -284,7 +284,7 @@ class DNSHandler():
 
         # HACK: It is important to search the nametodns dictionary before iterating it so that
         # global matching ['*.*.*.*.*.*.*.*.*.*'] will match last. Use sorting for that.
-        for domain,host in sorted(iter(nametodns.items()), key=operator.itemgetter(1)):
+        for domain,host in sorted(iter(nametodns.items()), key=lambda x: x[1] or ""):
 
             # NOTE: It is assumed that domain name was already lowercased
             #       when it was loaded through --file, --fakedomains or --truedomains


### PR DESCRIPTION
# Parameter `--truedomains` not working

Error in line [287](https://github.com/iphelix/dnschef/blob/master/dnschef.py#L287): `for domain,host in sorted(iter(nametodns.items()), key=operator.itemgetter(1)):`
Error text: `TypeError: '<' not supported between instances of 'str' and 'bool'`

The error occurs because the sort key can be strings and booleans.

## Dnschef output before fix:
![image](https://user-images.githubusercontent.com/24264685/107859867-79353780-6e4d-11eb-990a-b33bb13665c9.png)

## Dnschef output after fix:
![image](https://user-images.githubusercontent.com/24264685/107859888-8c480780-6e4d-11eb-83b8-5b21362444fe.png)
